### PR TITLE
fix: Remove the D2C_ prefix from viper calls

### DIFF
--- a/testdata/skip_bigfile.golden
+++ b/testdata/skip_bigfile.golden
@@ -1,1 +1,1 @@
-repo/a : a
+dir2consul/repo/a : a

--- a/testdata/skip_nothing.golden
+++ b/testdata/skip_nothing.golden
@@ -1,12 +1,12 @@
-repo/README : readme file
-repo/a/a : a
-repo/a/test-text : a
-repo/b/b : b
-repo/b/test-text : b
-repo/skipme : May be skipped.
-repo/skipme/another : another
-repo/skipme/skipme : May be skipped.
-repo/test-json : {
+dir2consul/repo/README : readme file
+dir2consul/repo/a/a : a
+dir2consul/repo/a/test-text : a
+dir2consul/repo/b/b : b
+dir2consul/repo/b/test-text : b
+dir2consul/repo/skipme : May be skipped.
+dir2consul/repo/skipme/another : another
+dir2consul/repo/skipme/skipme : May be skipped.
+dir2consul/repo/test-json : {
     "a": 1
 }
-repo/test-text : some text
+dir2consul/repo/test-text : some text

--- a/testdata/skip_readme_file.golden
+++ b/testdata/skip_readme_file.golden
@@ -1,11 +1,11 @@
-repo/a/a : a
-repo/a/test-text : a
-repo/b/b : b
-repo/b/test-text : b
-repo/skipme : May be skipped.
-repo/skipme/another : another
-repo/skipme/skipme : May be skipped.
-repo/test-json : {
+dir2consul/repo/a/a : a
+dir2consul/repo/a/test-text : a
+dir2consul/repo/b/b : b
+dir2consul/repo/b/test-text : b
+dir2consul/repo/skipme : May be skipped.
+dir2consul/repo/skipme/another : another
+dir2consul/repo/skipme/skipme : May be skipped.
+dir2consul/repo/test-json : {
     "a": 1
 }
-repo/test-text : some text
+dir2consul/repo/test-text : some text

--- a/testdata/skip_skipme_dir.golden
+++ b/testdata/skip_skipme_dir.golden
@@ -1,10 +1,10 @@
-repo/README : readme file
-repo/a/a : a
-repo/a/test-text : a
-repo/b/b : b
-repo/b/test-text : b
-repo/skipme : May be skipped.
-repo/test-json : {
+dir2consul/repo/README : readme file
+dir2consul/repo/a/a : a
+dir2consul/repo/a/test-text : a
+dir2consul/repo/b/b : b
+dir2consul/repo/b/test-text : b
+dir2consul/repo/skipme : May be skipped.
+dir2consul/repo/test-json : {
     "a": 1
 }
-repo/test-text : some text
+dir2consul/repo/test-text : some text

--- a/testdata/skip_skipme_file.golden
+++ b/testdata/skip_skipme_file.golden
@@ -1,10 +1,10 @@
-repo/README : readme file
-repo/a/a : a
-repo/a/test-text : a
-repo/b/b : b
-repo/b/test-text : b
-repo/skipme/another : another
-repo/test-json : {
+dir2consul/repo/README : readme file
+dir2consul/repo/a/a : a
+dir2consul/repo/a/test-text : a
+dir2consul/repo/b/b : b
+dir2consul/repo/b/test-text : b
+dir2consul/repo/skipme/another : another
+dir2consul/repo/test-json : {
     "a": 1
 }
-repo/test-text : some text
+dir2consul/repo/test-text : some text


### PR DESCRIPTION
The combination of SetEnvPrefix with AutomaticEnv magically prepends it.